### PR TITLE
Update: Added MVAPICH2 -- awaiting final approval

### DIFF
--- a/pkg/jm/jobmgr_slurm.go
+++ b/pkg/jm/jobmgr_slurm.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2001-2023, The Ohio State University. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +19,7 @@ import (
 	"github.com/gvallee/go_exec/pkg/advexec"
 	"github.com/gvallee/go_hpc_jobmgr/internal/pkg/network"
 	"github.com/gvallee/go_hpc_jobmgr/internal/pkg/openmpi"
+    "github.com/gvallee/go_hpc_jobmgr/internal/pkg/mvapich2"
 	"github.com/gvallee/go_hpc_jobmgr/internal/pkg/slurm"
 	"github.com/gvallee/go_hpc_jobmgr/pkg/job"
 	"github.com/gvallee/go_hpc_jobmgr/pkg/mpi"

--- a/pkg/mpi/mpi.go
+++ b/pkg/mpi/mpi.go
@@ -2,6 +2,7 @@
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
+// Copyright (c) 2001-2023, The Ohio State University. All rights reserved.
 
 package mpi
 
@@ -60,6 +61,9 @@ func GetMpirunArgs(myHostMPICfg *implem.Info, app *app.Info, sysCfg *sys.Config,
 	switch myHostMPICfg.ID {
 	case implem.OMPI:
 		extraArgs = append(extraArgs, openmpi.GetExtraMpirunArgs(sysCfg, netCfg, mpirunArgs)...)
+        break
+    case implem.MVAPICH2:
+        extraArgs = append(extraArgs, mvapich2.GetExtraMpirunArgs(sysCfg, netCfg, mpirunArgs)...)
 	}
 
 	return extraArgs, nil


### PR DESCRIPTION
Edits made in the commit:
mpi.go -- added a command in to add the extra arguments to MVAPICH2's runtime command. 
jobmgr_slurm.go -- currently using `mpirun` for MVAPICH. Maybe down the line, this will have support for MVAPICH's `mpirun_rsh` launcher and cmd-line arguments can be updated accordingly later on inside here and elsewhere -- tl;dr, `mpirun_rsh` doesn't use `-genv` or `-env`.